### PR TITLE
corrects menu import and css import, sample version 1.3.0

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="src/examples.css">
-    <link rel="stylesheet" type="text/css" href="tuiomanager/widgets/CircularMenu/circularmenu.css">
+    <link rel="stylesheet" type="text/css" href="node_modules/tuiomanager/widgets/CircularMenu/circularmenu.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <title>TUIOSamples</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuiosamples",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "scripts": {
     "devMode": "node initTUIOManagerDevMode.js",
     "dist": "node prod-webpack-compiler.js",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import $ from 'jquery/dist/jquery.min';
 // Import TUIOManager
 import TUIOManager from 'tuiomanager/core/TUIOManager';
 
-import { buildMenu } from './menu';
+import buildMenu from './menu';
 
 /** TUIOManager starter **/
 const tuioManager = new TUIOManager();


### PR DESCRIPTION
to import the css file node_modules is added. This is not the right way to do it, webpack should be able to do it. Adding 'css' to loader didn't work ...